### PR TITLE
Fix usage of cobalt after Angel mods pushed it to "crystal" tier.

### DIFF
--- a/prototypes/bobextended/bobextended-update-frame.lua
+++ b/prototypes/bobextended/bobextended-update-frame.lua
@@ -19,10 +19,10 @@ function momoTweak.require.ExtendedFrameUpdate()
 	  {"lead-plate", 7},{"plate-pack-1", 4},{"stone-brick", 14}
 	}
 	newRecipe("intermediate", 30).ingredients = {
-	  {"basic-structure-components", 2},{"brass-gear-wheel", 4},{"cobalt-plate", 3},{"invar-alloy", 14}
+	  {"basic-structure-components", 2},{"brass-gear-wheel", 4},{"aluminium-plate", 8},{"invar-alloy", 14}
 	}
 	newRecipe("advanced", 60).ingredients = {
-	  {"intermediate-structure-components", 2},{"tungsten-plate", 13},{"aluminium-plate", 16},
+	  {"intermediate-structure-components", 2},{"tungsten-plate", 13},{"cobalt-plate", 20},
 	  {"titanium-plate", 22},{"cobalt-steel-alloy", 10},{"advanced-plastics", 80}
 	}
 	newRecipe("anotherworld", 120).ingredients = {

--- a/prototypes/recipe/logistic.lua
+++ b/prototypes/recipe/logistic.lua
@@ -139,7 +139,7 @@ bobmods.lib.recipe.add_ingredient(chargepad .. "-1", {"nickel-plate", 2})
 
 local types = {"passive-provider", "active-provider", "storage", "requester", "buffer"}
 for i, t in pairs(types) do
-	bobmods.lib.recipe.add_ingredient("logistic-chest-" .. t, {"cobalt-plate", 3})
+	bobmods.lib.recipe.add_ingredient("logistic-chest-" .. t, {"zinc-plate", 3})
 end
 
 for i, t in pairs(types) do
@@ -167,6 +167,6 @@ bobmods.lib.recipe.add_ingredient("big-electric-pole-4", {"cobalt-plate", 20})
 bobmods.lib.recipe.add_ingredient("substation-3", {"cobalt-plate", 10})
 bobmods.lib.recipe.add_ingredient("substation-4", {"cobalt-plate", 25})
 
-bobmods.lib.recipe.add_ingredient("electric-engine-unit", {"cobalt-plate", 5})
+bobmods.lib.recipe.add_ingredient("electric-engine-unit", {"steel-bearing", 7})
 bobmods.lib.recipe.add_ingredient("storage-tank-3", {"cobalt-plate", 25})
 bobmods.lib.recipe.add_ingredient("storage-tank-4", {"tungsten-plate", 25})

--- a/prototypes/sci/recipe.lua
+++ b/prototypes/sci/recipe.lua
@@ -146,7 +146,7 @@ function momoTweak.require.SciRecipe()
 	momoTweak.createRecipe(sci_cat, {{"py-nxag-matrix", 2}},
 	  {
 		{"titanium-plate", 6},
-		{"cobalt-steel-alloy", 4},
+		{"cobalt-steel-alloy", 6},
 		{"building-pack", 7},
 		{"electric-engine-unit", 1},
 		{"lithium-ion-battery", 6},


### PR DESCRIPTION
Fix usage of cobalt after Angel mods pushed it to "crystal" tier.

- replace it with aluminium, zinc, or steel bearing in recipes that are at "chunk" tier

Is needed because otherwise at some point is impossible to progress (at "intermediate structure components" and "leaching plant") - more info: https://mods.factorio.com/mod/MomosTweak/discussion/6114f8c44232fcfb072e08b7 