### PR TITLE
SeaBlock: fix for uncraftable early machines like "Electrolyser 1" - see issue #6

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,11 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.1.6
+Date: 2022.06.23
+  Fixed:
+	- SeaBlock: fix for uncraftable early machines like "Electrolyser 1" . See: https://github.com/Archemide/MomosTweak/pull/7
+	    - also ensure alginic acid is handcraftable
+        - also add way to crush stone into crushed stone, and that into sand
+---------------------------------------------------------------------------------------------------
 Version: 1.1.5
 Date: 2022.06.20
   Fixed:

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -20,6 +20,7 @@ require("prototypes.sci.final-fix")
 data.raw.item[momoTweak.burner].subgroup = data.raw.item["assembling-machine-1"].subgroup
 
 require("prototypes.fix-angels-machine")
+require("prototypes.fix-seablock-machines")
 require("prototypes.sci.sci30result-preset")
 
 if not momoTweak.isLoadScienceRecipeInUpdates then

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "MomosTweak",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "factorio_version": "1.1",
   "title": "MomosTweak",
   "author": "Archemide",

--- a/prototypes/angel-bio.lua
+++ b/prototypes/angel-bio.lua
@@ -171,7 +171,10 @@ function momoTweak.angelBio.FinalFixed()
 end
 
 function momoTweak.angel_electrolysis_recipe()
-	data.raw.recipe["solid-alginic-acid"].category = "electrolysis"
+	-- If SeaBlock mod is loaded then this alginic acid needs to be handcraftable for basic circuits - so in such case do not move this recipe to electrolysis:
+	if not mods["SeaBlock"] then
+		data.raw.recipe["solid-alginic-acid"].category = "electrolysis"
+	end
 end
 
 

--- a/prototypes/fix-seablock-machines.lua
+++ b/prototypes/fix-seablock-machines.lua
@@ -1,0 +1,13 @@
+if mods["SeaBlock"] then
+	-- remove "Basic Structure components" ingredient from machines which are essential to SeaBlock's early game:
+	bobmods.lib.recipe.remove_ingredient("angels-electrolyser", "basic-structure-components")
+	bobmods.lib.recipe.remove_ingredient("crystallizer", "basic-structure-components")
+	bobmods.lib.recipe.remove_ingredient("filtration-unit", "basic-structure-components")
+
+	-- move "Tead combination plate" recipes to "Steel processing" technology:
+	-- (is to make "Basic Structure components" actually craftable)
+	bobmods.lib.tech.add_recipe_unlock("steel-processing", "momo-plate-pack-1-N1")
+	bobmods.lib.tech.add_recipe_unlock("steel-processing", "momo-tinplate-pack-1-N1")
+	bobmods.lib.tech.remove_recipe_unlock("logistic-science-pack", "momo-plate-pack-1-N1")
+	bobmods.lib.tech.remove_recipe_unlock("logistic-science-pack", "momo-tinplate-pack-1-N1")
+end

--- a/prototypes/recipe/sandclay.lua
+++ b/prototypes/recipe/sandclay.lua
@@ -40,6 +40,13 @@ if data.raw.item["solid-clay"] and data.raw.item["solid-coke"] then
 end
 
 
+local limestoneSandCategory = "ore-sorting-t1"
+if data.raw["recipe-category"] ~= nil then
+    if data.raw["recipe-category"][ "ore-refining-t1"] ~= nil then
+        limestoneSandCategory = "ore-refining-t1"
+    end
+end
+
 --angel mud to sand
 if data.raw["assembling-machine"]["washing-plant"] then
 	data:extend({{
@@ -62,13 +69,6 @@ if data.raw["assembling-machine"]["washing-plant"] then
 		 icon_size = 32
 	}})
 	bobmods.lib.tech.add_recipe_unlock("water-washing-1", "momo-mud-sand")
-
-	local limestoneSandCategory = "ore-sorting-t1"
-	if data.raw["recipe-category"] ~= nil then
-		if data.raw["recipe-category"][ "ore-refining-t1"] ~= nil then
-			limestoneSandCategory = "ore-refining-t1"
-		end
-	end
 
 	data:extend({{
 		 type = "recipe",
@@ -98,6 +98,21 @@ if data.raw["recipe-category"]["biofarm-mod-crushing"] then
 	{{"stone-crushed", 2}}, 
 	4, momoTweak.get_tech_of_recipe("bi_recipe_stone_crusher"), "sand-upgrade")
 end
+
+if mods["SeaBlock"] then
+    momoTweak.createRecipe(limestoneSandCategory,
+    {{"solid-sand", 3}},
+    {{"stone-crushed", 2}},
+    4, true, "stone-crushed-crushing-to-sand")
+
+
+    momoTweak.createRecipe(limestoneSandCategory,
+    {{"stone-crushed", 2}},
+    {{"stone", 3}},
+    4, true, "stone-crushing-to-crushed-stone")
+end
+
+
 
 momoTweak.createRecipe("chemical-furnace", {{"glass", 1}}, {
 	{type="item", name="solid-sand", amount=12},


### PR DESCRIPTION
- fixes #6
- also ensure alginic acid is handcraftable
- also add way to crush stone into crushed stone, and that into sand

thanks @ChrisJStone for report 👍 