### PR TITLE
Feature/version 1.2.0 (angelsindustries support etc)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,14 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.2.0
+Date: 2022.09.06
+  Change:
+    - added compatibility with following mods: angelsindustries ( https://mods.factorio.com/mod/angelsindustries ), "P-U-M-P-S" / "osm-lib" ( https://mods.factorio.com/mod/P-U-M-P-S )
+  Added:
+    - tests for "progression block". See: function/recipe.lua . They can be executed manually at end of data-final-fixes.lua to see if anything like recipes, technologies etc block player progression up to "satellite". If player can craft satellite then OK - if not then in factorio-current.log (in your Factorio dir) you should see reasons why some science packs and their ingredients are not craftable.
+  Fixed:
+	- some things blocking craftability of science packs related to mods: angelsindustries, MoreSciencePacks-for1_1, SeaBlock
+	    - Thanks to user mlxix for report: https://mods.factorio.com/mod/MomosTweak/discussion/630abdf4df42b7581198be96
+---------------------------------------------------------------------------------------------------
 Version: 1.1.11
 Date: 2022.08.26
   Fixed:

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -1,3 +1,213 @@
+
+local angelsindustries_affected_electronics = {
+	-- electronics
+	{
+		name = "basic-circuit-board", -- localised name: "Basic circuit board" (first circuit board)
+		shouldRecipeBeEnabledFromStart = true,
+	},
+	--{
+	--	name = "basic-electronic-board", -- DOESNT EXISTS
+	--},
+	{
+		name = "electronic-circuit", -- localised name: "Basic electronic board" (second circuit board)
+		unlock_tech = "electronics"
+	},
+	{
+		name = "advanced-circuit", -- localised name: "Electronic circuit board" (red color)
+		unlock_tech = "advanced-electronics"
+	},
+	{
+		name = "processing-unit", -- localised name: "Electronic logic board" (blue color)
+		unlock_tech = "advanced-electronics-2"
+	},
+	{
+		name = "advanced-processing-unit", -- localised name: "Electronic processing board" (purple color)
+		unlock_tech = "advanced-electronics-3"
+	},
+	-- electronic components/boards
+	{
+		name = "wooden-board", -- localised name: "Wooden board"
+		shouldRecipeBeEnabledFromStart = true,
+	},
+	{
+		name = "phenolic-board", -- localised name: "Phenolic board"
+		unlock_tech = "advanced-electronics"
+	},
+	{
+		name = "fibreglass-board", -- localised name: "Fibreglass board"
+		unlock_tech = "advanced-electronics-2"
+	},
+	{
+		name = "circuit-board", -- localised name: "Circuit board" (is red board used as ingredient for "advanced-circuit")
+		unlock_tech = "advanced-electronics"
+	},
+	{
+		name = "superior-circuit-board", -- localised name: "Superior circuit board" (is blue board used as ingredient for "processing-unit")
+		unlock_tech = "advanced-electronics-2"
+	},
+	{
+		name = "multi-layer-circuit-board", -- localised name: "Multi-layer circuit board" (is purple board used as ingredient for "advanced-processing-unit")
+		unlock_tech = "advanced-electronics-3"
+	},
+	{
+		name = "basic-electronic-components", -- localised name: "Basic electronic components"
+		unlock_tech = "electronics"
+	},
+	{
+		name = "electronic-components", -- localised name: "Transistors"
+		unlock_tech = "advanced-electronics"
+	},
+	{
+		name = "intergrated-electronics", -- localised name: "Integrated electronics"
+		unlock_tech = "advanced-electronics-2"
+	},
+	{
+		name = "processing-electronics", -- localised name: "CPUs"
+		unlock_tech = "advanced-electronics-3"
+	},
+
+	-- gears
+	{
+		name = "brass-gear-wheel",
+		unlock_tech = "zinc-processing"
+	},
+	{
+		name = "cobalt-steel-gear-wheel",
+		unlock_tech = "angels-cobalt-steel-smelting-1"
+	},
+
+	-- batteries
+	{
+		name = "lithium-ion-battery",
+		unlock_tech = "advanced-electronics-2"
+	},
+	{
+		name = "silver-zinc-battery",
+		unlock_tech = "advanced-electronics-3"
+	},
+}
+
+
+local angelsindustries_restore_electronics = {
+	-- electronics
+	{"basic-circuit-board", "circuit-grey"},
+	{"electronic-circuit", "circuit-red-loaded"},
+	{"advanced-circuit","circuit-green-loaded"},
+	{"processing-unit","circuit-blue-loaded"},
+	{"advanced-processing-unit","circuit-yellow-loaded"},
+	-- electronic components/boards
+	--{"wooden-board","circuit-grey-board"},
+	{"phenolic-board","circuit-orange-board"},
+	{"fibreglass-board","circuit-blue-board"},
+	{"circuit-board","circuit-orange"},
+	{"superior-circuit-board","circuit-blue"},
+	{"multi-layer-circuit-board","circuit-yellow"},
+	{"basic-electronic-components","circuit-resistor"},
+	{"electronic-components","circuit-transistor"},
+	{"intergrated-electronics","circuit-microchip"},
+	{"processing-electronics","circuit-cpu"},
+}
+
+
+if momoTweak.mods.angelsindustries then
+	-- Fix for mod "angelsindustries":
+	-- 1. Loop to reenable electronic ingredients (see list: prototypes/overrides/replacement-fallbacks.lua   and angelsmods.functions.AI.replace_gen_mats() )
+	--        ^ also replace their ingredients. For example: in "electronic-circuit" recipe replace "circuit-grey" with "basic-circuit-board" etc
+	--        ^ also fix: battery, li-ion battery, silver-zinc battery
+	--                ^ TODO: should we add li-ion and silver-zinc to some angelsindustries batteries recipes? Or also to "Pyanodons super conductor"? Accumulators, compnents for high tier robots?
+	--        ^ TODO: add "Another world structure compnents" to more builidngs?
+	-- 2. add "momo electronic circuits" to recipes of corresponding "angelsindustries circuits". Check if there is no "circular references". Also in the "momo circuits" recipes replace "angelsindustries boards" with "momo boards".
+	-- 2. Perform tests also for progression locks on following sets of mods: same but without angelsindustries (with various settings of this mod off/on (especially components)), SeaBlock pack (with and without angelsindustries - but keep in mind that with it overwrites settings - see "settings-updates/angelsindustries.lua" in SeaBlock mod), MSP30 with its science packs in labs (not in chips), the save "new_save - bug with paper reproduction" (130 mods)
+
+
+	for _,item_data in pairs(angelsindustries_affected_electronics) do
+		if data.raw.item[item_data.name] ~= nil then
+			local shouldRecipeBeEnabledFromStart = false
+			if item_data.shouldRecipeBeEnabledFromStart == true then shouldRecipeBeEnabledFromStart = true end
+
+			momoIRTweak.recipe.reEnableItem(item_data.name)
+			momoIRTweak.recipe.reEnableRecipe(item_data.name, shouldRecipeBeEnabledFromStart)
+			momoIRTweak.recipe.ChangeRecipeResults(item_data.name,  {
+				{
+					amount = 1,
+					name = item_data.name,
+					type = "item"
+				}
+			})
+			if item_data.unlock_tech ~= nil then
+				bobmods.lib.tech.add_recipe_unlock(item_data.unlock_tech, item_data.name)
+			end
+		end
+	end
+	-- make sure that with mod MSP30 we are not blocke don that tech:
+	bobmods.lib.tech.remove_science_pack("advanced-electronics", "more-science-pack-9")
+	bobmods.lib.tech.remove_science_pack("advanced-electronics", "more-science-pack-10")
+
+
+	-- Fix batteries:
+	momoTweak.replace_with_ingredient_in_all_recipes("battery", "battery-1")
+	momoTweak.replace_with_ingredient_in_all_recipes("lithium-ion-battery", "battery-3")
+	momoTweak.replace_with_ingredient_in_all_recipes("silver-zinc-battery", "battery-6")
+	momoTweak.replace_with_ingredient("lithium-ion-battery", "lithium-cobalt-oxide", {"solid-lithium", 2})
+	momoTweak.replace_with_ingredient("lithium-ion-battery", "battery", {"battery-1", 1})
+	bobmods.lib.recipe.add_ingredient("lithium-ion-battery", {"battery-2", 1})
+	momoTweak.replace_with_ingredient("momo-py-superconductor-N4", "battery-6", {"battery-4", 4})
+	momoTweak.replace_with_ingredient("utility-science-pack", "battery-3", {"silver-zinc-battery", 4})
+
+	-- Restore Bobs/Momos electronic components in those:
+	for _,item_data in pairs(angelsindustries_affected_electronics) do
+		for _,replacement in pairs(angelsindustries_restore_electronics) do
+			if data.raw.recipe[item_data.name] ~= nil then
+				bobmods.lib.recipe.replace_ingredient(item_data.name, replacement[2], replacement[1])
+			end
+		end
+	end
+
+	-- Add Bobs/Momos electronic components to "angelsindustries" circuits:
+	bobmods.lib.recipe.add_ingredient("circuit-red-loaded", {"electronic-circuit", 1})
+	bobmods.lib.recipe.add_ingredient("circuit-green-loaded", {"electronic-circuit", 2})
+	bobmods.lib.recipe.add_ingredient("circuit-orange-loaded", {"advanced-circuit", 1})
+	bobmods.lib.recipe.add_ingredient("circuit-blue-loaded", {"processing-unit", 1})
+	bobmods.lib.recipe.add_ingredient("circuit-yellow-loaded", {"advanced-processing-unit", 1})
+
+	-- Fix tiers in other recipes:
+	bobmods.lib.recipe.remove_ingredient("stone-wall", "block-construction-2")
+	momoTweak.replace_with_ingredient("electric-chemical-mixing-furnace", "construction-frame-5", "construction-frame-4")
+	momoIRTweak.recipe.reEnableRecipe("boiler", true)
+end
+
+
+if mods["P-U-M-P-S"] then
+	local pumpsModBrokenSciencePack5 = false
+	if data.raw.recipe["more-science-pack-5"] ~= nil and data.raw.recipe["more-science-pack-5"].ingredients ~= nil then
+		for _,ingredient in pairs(data.raw.recipe["more-science-pack-5"].ingredients) do
+			if ingredient.name == "OSM-hoffman-void-recipe" then
+				pumpsModBrokenSciencePack5 = true
+			end
+		end
+	end
+
+	if pumpsModBrokenSciencePack5 then
+		momoTweak.replace_with_ingredient("more-science-pack-5", "OSM-hoffman-void-recipe", {"boiler", 4})
+		bobmods.lib.recipe.add_ingredient("more-science-pack-5", {"basic-circuit-board", 3})
+		data.raw.recipe["more-science-pack-5"].category = "basic-crafting"
+		data.raw.recipe["more-science-pack-5"].icons = nil
+		data.raw.recipe["more-science-pack-5"].localised_description = nil
+
+		momoIRTweak.recipe.reEnableRecipe("boiler", true)
+	end
+end
+
+
+if mods["Bio_Industries"] then
+	if data.raw.recipe["bi-production-science-pack"] ~= nil then
+		data.raw.recipe["bi-production-science-pack"].enabled = false
+		data.raw.recipe["bi-production-science-pack"].hidden = true
+	end
+end
+
+
+
 require("prototypes.sci.sct-pre-process")
 
 if not momoTweak.isLoadScienceRecipeInUpdates then
@@ -48,6 +258,11 @@ momoTweak.ReworkPressureTank()
 
 require("fix")
 
+
+
+
+
+
 local count = 0
 for	c, r in pairs(data.raw.recipe) do
 	count = count + 1
@@ -61,3 +276,25 @@ for	c, t in pairs(data.raw.technology) do
 end
 
 log("Total technology = " .. count)
+
+
+
+--[[
+log("Momo data-final-fixes.lua::end - begin printing electronic recipes")
+-- Note: we should keep this in sync with angelsmods.industries.general_replace from "prototypes/overrides/replacement-fallbacks.lua" from "angelsindustries" mod
+for _,item_data in pairs(angelsindustries_affected_electronics) do
+	if data.raw["recipe"][item_data.name] ~= nil then
+		log("Momo data-final-fixes.lua::end - recipe " .. item_data.name .. ": " .. tostring(serpent.block(data.raw["recipe"][item_data.name])))
+	else
+		log("Momo data-final-fixes.lua::end - recipe " .. item_data.name .. " - DOESNT EXISTS")
+	end
+end
+log("Momo data-final-fixes.lua::end - finished printing electronic recipes")
+--]]
+
+
+
+-- You can run tests there for both difficulties:
+--require("function-tests")
+--automatic_mod_tests.functions.executeTests('normal')
+--automatic_mod_tests.functions.executeTests('expensive')

--- a/data.lua
+++ b/data.lua
@@ -9,7 +9,8 @@ momoTweak.settings.isLoadBobExtended = true
 
 momoTweak.mods.sct = mods["ScienceCostTweakerM"]
 momoTweak.mods.angelBio = mods["angelsbioprocessing"]
-momoTweak.mods.msp = mods["MoreSciencePacks"] or mods["MoreSciencePacks-for1_1"]
+momoTweak.mods.angelsindustries = mods["angelsindustries"] and settings.startup["angels-enable-industries"] ~= nil and settings.startup["angels-enable-industries"].value == true and settings.startup["angels-enable-components"] ~= nil and settings.startup["angels-enable-components"].value == true
+momoTweak.mods.msp = mods["MoreSciencePacks"] or mods["MoreSciencePacks-for1_1"] -- aka MSP30 or MSP
 momoTweak.mods.bioIndustries = mods["Bio_Industries"]
 momoTweak.mods.modularChests = mods["LB-Modular-Chests"]
 momoTweak.mods.undergroundPipePack = mods["underground-pipe-pack"]

--- a/function-tests.lua
+++ b/function-tests.lua
@@ -1,0 +1,534 @@
+if not automatic_mod_tests then automatic_mod_tests = {} end
+if not automatic_mod_tests.functions then automatic_mod_tests.functions = {} end
+
+--[[
+Goal: create automatic test for 'no progression blocker':
+    * General algorithm should loop like this until it reaches satellite:
+        vars: "researched_recipes", "craftable_items" (maybe?: "craftable_fluids")
+        1. Gather all researched recipes (with enabled==true, hidden != true) - save in "researched_recipes"
+            1a. TODO: Ignore recipes like: barelling/unbarreling, stacking/unstacking, boxes/unboxes (crates?), compressing/uncompressing fluids (pressurized fluids), burning in furnaces (in Pyanadon), crushing in crushers to nothing (AAI or SpaceExploration?), SpaceExploration capsules & unpacking of rocket sections/parts.
+                ^ is mainly for performance reasons? Or maybe it will prevent false positive scenarios?
+                ^ also: recipe.results contains: { amount = 1, name = "chemical-void" }
+        2. Go through all items/fluids that can be "mined" (or pumped from "pumpjacks", "offshore pumps" etc) - add them to "craftable_items".
+            2a. So start from looping through entities which are miners, pumps etc - and check what are they mining. Then loop through all resources which fit those machines and take items which are mined from them and put them in "craftable_items".
+            2b. Make sure that each item is not hidden etc before adding it.
+            2c. Make sure there is machine (mining drill, pumpjack) - which is reasearched and craftable - that can "mine" such item/fluid.
+        3. Go through "researched_recipes" and for each check if is craftable - so if all ingredient items are in "craftable_items". :
+            3a. TODO: Also check if there exists (researched and craftable) entity (machine) which can craft such recipe (check recipe category vs crafting categories of entity etc).
+            3b. If such recipe is craftable then: Add all items from its result(s) to "craftable_items" and remove said recipe from "researched_recipes"
+                ^ Make sure that each item is not hidden etc before adding it.
+        4. Go through all technologies which are possible to research at this moment. For each check if all required science packs are craftable - if yes then consider such technology researched. In such case add all recipes which this technology unlocks to "researched_recipes"
+            4a. Make sure to check https://wiki.factorio.com/Prototype/Technology#enabled is not false
+            4b. Consider specific "technology difficulty" (normal or expensive) - https://wiki.factorio.com/Prototype/Technology#Technology_data
+            4c. Make sure to check prerequisites
+        5. If "satellite" is in "craftable_items" then end with success. If there was any change in "researched_recipes" or "craftable_items" or technologies researched (without infinite ones - https://wiki.factorio.com/Prototype/Technology#max_level ) then go to point 2, else end with failure.
+            5a. in case of failure write to log: "researched_recipes", "craftable_items", technologies researched, technologies possible to research, science packs needed for said technologies.
+
+    Other notes for tests:
+    ** we should try doing whole loop for "normal" and "expensive" difficulty of recipes ( see https://wiki.factorio.com/Prototype/Recipe#Recipe_data )
+    ** we should create a separate mod with such tests - this way will be easier to reuse it later (just add mod in Factorio and observe log etc).
+        ^ Add dependencies for other mods to it - so this "test mod" will be loaded after all other mods.
+--]]
+
+function automatic_mod_tests.functions.executeTests(difficulty)
+    log("automatic_mod_tests.functions.executeTests::start - executing for difficulty: " .. difficulty)
+
+    local researched_recipes = {}
+    local researched_technologies = {}
+    local craftable_items = {}
+    local craftable_fluids = {}
+    local craftable_entities = {}
+
+    local minable_resource_categories = {}
+
+    local test_iteration_number = 0
+
+    --log("automatic_mod_tests log => automatic_mod_tests.functions.executeTests - recipe electric-mining-drill: " .. tostring(serpent.block(data.raw.recipe['electric-mining-drill'])))
+    --log("automatic_mod_tests log => automatic_mod_tests.functions.executeTests - recipe momo-building-pack-N1: " .. tostring(serpent.block(data.raw.recipe['momo-building-pack-N1'])))
+    --log("automatic_mod_tests log => automatic_mod_tests.functions.executeTests - recipe more-science-pack-1: " .. tostring(serpent.block(data.raw.recipe['more-science-pack-1'])))
+    --log("automatic_mod_tests log => automatic_mod_tests.functions.executeTests - recipe more-science-pack-5: " .. tostring(serpent.block(data.raw.recipe['more-science-pack-5'])))
+
+
+    -- fish can be obtained from map manually:
+    craftable_items['raw-fish'] = true
+    -- lets assume steam is craftable:
+    craftable_fluids['steam'] = true
+
+    if mods["angelsbioprocessing"] ~= nil then
+        -- add those big trees and gardens to craftable items because they can be mined manually from map by player:
+        craftable_items['desert-tree'] = true
+        craftable_items['swamp-tree'] = true
+        craftable_items['temperate-tree'] = true
+        craftable_items['desert-garden'] = true
+        craftable_items['swamp-garden'] = true
+        craftable_items['temperate-garden'] = true
+    end
+
+    if mods["SeaBlock"] then
+        craftable_items['angels-ore1-crushed'] = true -- saphirite
+        craftable_items['angels-ore3-crushed'] = true -- stiratite
+        craftable_items['cellulose-fiber'] = true -- craftable by hand (infinite)
+    end
+
+    if mods["SeaBlock"] == nil then
+        -- can be obtained from chopping wood:
+        craftable_items['wood'] = true
+    end
+
+
+    -- Note: This is point 1 in our "automatic test plan"
+    for _,recipe in pairs(data.raw.recipe) do
+        if recipe[difficulty] ~= nil then
+            if recipe[difficulty].enabled == true or recipe[difficulty].enabled == "true" or recipe[difficulty].enabled == nil then
+                researched_recipes[recipe.name] = true
+            end
+        else
+            if recipe.enabled == true or recipe.enabled == "true" or recipe.enabled == nil then
+                researched_recipes[recipe.name] = true
+            end
+        end
+    end
+
+
+    while test_iteration_number < 70 do
+        test_iteration_number = test_iteration_number + 1
+
+        -- Note: This is point 2 in our "automatic test plan"
+        automatic_mod_tests.functions.perform_point_2__populate_craftable_items_and_fluids_from_resources(researched_recipes, craftable_items, craftable_fluids, craftable_entities, minable_resource_categories, test_iteration_number > 1)
+
+        -- Note: This is point 3 in our "automatic test plan"
+        automatic_mod_tests.functions.perform_point_3__populate_craftable_items_from_recipes(researched_recipes, craftable_items, craftable_fluids, difficulty)
+
+        -- Note: This is point 4 in our "automatic test plan"
+        automatic_mod_tests.functions.perform_point_4__research_technologies(researched_technologies, researched_recipes, craftable_items, difficulty)
+    end
+
+
+    if craftable_items['satellite'] == nil then
+        log("function-tests.lua - automatic_mod_tests.functions.executeTests::end - researched_recipes(" .. tostring(automatic_mod_tests.functions.tableLength(researched_recipes)) .. "): " .. tostring(serpent.block(researched_recipes)))
+
+        log("function-tests.lua - automatic_mod_tests.functions.executeTests::end - craftable_items(" .. tostring(automatic_mod_tests.functions.tableLength(craftable_items)) .. "): " .. tostring(serpent.block(craftable_items)))
+        --log("function-tests.lua - automatic_mod_tests.functions.executeTests::end - craftable_items(" .. tostring(automatic_mod_tests.functions.tableLength(craftable_items)) .. "): " .. tostring(serpent.dump(craftable_items)))
+        log("function-tests.lua - automatic_mod_tests.functions.executeTests::end - craftable_fluids(" .. tostring(automatic_mod_tests.functions.tableLength(craftable_fluids)) .. "): " .. tostring(serpent.block(craftable_fluids)))
+        log("function-tests.lua - automatic_mod_tests.functions.executeTests::end - craftable_entities(" .. tostring(automatic_mod_tests.functions.tableLength(craftable_entities)) .. "): " .. tostring(serpent.block(craftable_entities)))
+        log("function-tests.lua - automatic_mod_tests.functions.executeTests::end - minable_resource_categories(" .. tostring(automatic_mod_tests.functions.tableLength(minable_resource_categories)) .. "): " .. tostring(serpent.block(minable_resource_categories)))
+
+        log("function-tests.lua - automatic_mod_tests.functions.executeTests::end - researched_technologies(" .. tostring(automatic_mod_tests.functions.tableLength(researched_technologies)) .. "): " .. tostring(serpent.block(researched_technologies)))
+
+
+        automatic_mod_tests.functions.log_science_packs_missing_ingredients(craftable_items, craftable_fluids, researched_recipes, difficulty)
+    else
+        log("function-tests.lua - automatic_mod_tests.functions.executeTests::end - satellite is craftable - congratulations!")
+    end
+
+    log("function-tests.lua - automatic_mod_tests.functions.executeTests::end - finished for difficulty: " .. difficulty)
+end
+
+
+
+-- -----------------------------------------------------------------------------
+-- Functions to perform major steps of tests:
+
+
+function automatic_mod_tests.functions.perform_point_2__populate_craftable_items_and_fluids_from_resources(researched_recipes, craftable_items, craftable_fluids, craftable_entities, minable_resource_categories, is_beginning_of_game)
+    for _,entity_type in pairs({"mining-drill", "offshore-pump"}) do
+        for _,entity in pairs(data.raw[entity_type]) do
+            -- only process entity if is craftable (if there is recipe for it):
+            if automatic_mod_tests.functions.is_entity_craftable(researched_recipes, craftable_items, entity.name, is_beginning_of_game) then
+                if craftable_entities[entity.type] == nil then
+                    craftable_entities[entity.type] = {}
+                end
+                craftable_entities[entity.type][entity.name] = true
+            end
+        end
+    end
+
+    for entity_type,entities in pairs(craftable_entities) do
+        for entity_name in pairs(entities) do
+            if entity_type == "mining-drill" then
+                for _,resource_category in pairs(data.raw[entity_type][entity_name].resource_categories) do
+                    minable_resource_categories[resource_category] = true
+                end
+            elseif entity_type == "offshore-pump" then
+                craftable_fluids[data.raw[entity_type][entity_name].fluid] = true
+            end
+        end
+    end
+
+    for _,entity in pairs(data.raw.resource) do
+        local entity_category = entity.category or 'basic-solid'
+        if minable_resource_categories[entity_category] ~= nil then
+            if entity.minable.results ~= nil then
+                for _,minable_result in pairs(entity.minable.results) do
+                    if minable_result.type == 'item' then
+                        craftable_items[minable_result.name] = true
+                    elseif minable_result.type == 'fluid' then
+                        craftable_fluids[minable_result.name] = true
+                    end
+                end
+            else
+                craftable_items[entity.minable.result] = true
+            end
+        end
+    end
+end
+
+function automatic_mod_tests.functions.perform_point_3__populate_craftable_items_from_recipes(researched_recipes, craftable_items, craftable_fluids, difficulty)
+    for recipe_name,_ in pairs(researched_recipes) do
+        local recipeObject = data.raw.recipe[recipe_name]
+        local converted_ingredients = automatic_mod_tests.functions.convert_recipe_ingredients(recipeObject, difficulty)
+
+        -- TODO: check if there is a machine which can use this recipe?
+        -- TODO: this is hardcoded check for 'token-bio' momo recipe for "bio industries" mod:
+        local machineExistsToCraftThis = true;
+        if recipeObject.category == "bio-processor" and recipeObject.name == "momo-token-bio-N1" then
+            machineExistsToCraftThis = false
+        end
+
+
+        local are_ingredients_craftable = function(a_converted_ingredients, a_craftable_items, a_craftable_fluids)
+            for _,ingredient_item_name in pairs(a_converted_ingredients.craftable_items) do
+                if a_craftable_items[ingredient_item_name] == nil then
+                    -- not craftable
+                    return false
+                end
+            end
+            for _,ingredient_fluid_name in pairs(a_converted_ingredients.craftable_fluids) do
+                if a_craftable_fluids[ingredient_fluid_name] == nil then
+                    -- not craftable
+                    return false
+                end
+            end
+            return true
+        end
+
+        if machineExistsToCraftThis
+            and are_ingredients_craftable(converted_ingredients, craftable_items, craftable_fluids)
+        then
+            local converted_results = automatic_mod_tests.functions.convert_recipe_results(recipeObject, difficulty)
+            for _,result_item_name in pairs(converted_results.craftable_items) do
+                craftable_items[result_item_name] = true
+
+                -- TODO: (performance) consider removing recipe from researched_recipes (we will not need it later?)
+            end
+
+            for _,result_fluid_name in pairs(converted_results.craftable_fluids) do
+                craftable_fluids[result_fluid_name] = true
+            end
+        end
+    end
+end
+
+
+function automatic_mod_tests.functions.perform_point_4__research_technologies(researched_technologies, researched_recipes, craftable_items, difficulty)
+    local technologyDataByDifficulty = {}
+    local whitelist_ingredients = {}
+    if mods["SeaBlock"] then
+        whitelist_ingredients = {
+            ["sb-angelsore3-tool"] = true,
+            ["sb-algae-brown-tool"] = true,
+            ["sb-basic-circuit-board-tool"] = true,
+            ["sb-lab-tool"] = true,
+        }
+    end
+
+    local are_prerequisites_met = function(technologyDataPrerequisites, a_researched_technologies)
+        if technologyDataPrerequisites ~= nil and not automatic_mod_tests.functions.isTableEmpty(technologyDataPrerequisites) then
+            for _,prerequisite in pairs(technologyDataPrerequisites) do
+                if a_researched_technologies[prerequisite] == nil then
+                    return false
+                end
+            end
+        end
+        return true
+    end
+
+    local are_ingredients_craftable = function(a_technologyData, a_craftable_items, a_whitelist_ingredients)
+        if a_technologyData.unit == nil or automatic_mod_tests.functions.isTableEmpty(a_technologyData.unit) then
+            return true
+        end
+        if a_technologyData.unit.ingredients == nil or automatic_mod_tests.functions.isTableEmpty(a_technologyData.unit.ingredients) then
+            return true
+        end
+
+        local converted_ingredients = automatic_mod_tests.functions.convert_technology_ingredients(a_technologyData.unit.ingredients)
+
+        for _,ingredient_item_name in pairs(converted_ingredients) do
+            if a_whitelist_ingredients[ingredient_item_name] == nil and a_craftable_items[ingredient_item_name] == nil then
+                return false
+            end
+        end
+
+        return true
+    end
+
+
+    for _,tech in pairs(data.raw.technology) do
+        if researched_technologies[tech.name] == nil then
+            -- handle technology difficulty: https://wiki.factorio.com/Prototype/Technology#Technology_data
+            if tech[difficulty] ~= nil then
+                technologyDataByDifficulty = tech[difficulty]
+            else
+                technologyDataByDifficulty = tech
+            end
+
+
+            if technologyDataByDifficulty.max_level ~= "infinite"
+                and are_prerequisites_met(technologyDataByDifficulty.prerequisites, researched_technologies)
+                and are_ingredients_craftable(technologyDataByDifficulty, craftable_items, whitelist_ingredients)
+            then
+                researched_technologies[tech.name] = true
+
+                if technologyDataByDifficulty.effects ~= nil and not automatic_mod_tests.functions.isTableEmpty(technologyDataByDifficulty.effects) then
+                    for _,effect in pairs(technologyDataByDifficulty.effects) do
+                        if effect.type == "unlock-recipe" then
+                            researched_recipes[effect.recipe] = true
+                        end
+                    end
+                end
+            end
+
+        end
+    end
+end
+
+
+
+-- -----------------------------------------------------------------------------
+-- Logging functions:
+
+
+function automatic_mod_tests.functions.log_science_packs_missing_ingredients(craftable_items, craftable_fluids, researched_recipes, difficulty)
+    -- type: lab, check property for science packs: "inputs"
+
+    local all_lab_tools = {}
+
+    for _, entity in pairs(data.raw.lab) do
+        --[[
+        example of entity.inputs (those are items of type "tool"):
+
+        {
+          "automation-science-pack",
+          "logistic-science-pack",
+          "military-science-pack",
+          "chemical-science-pack",
+          "production-science-pack",
+          "utility-science-pack",
+          "space-science-pack",
+          "advanced-logistic-science-pack",
+          "token-bio"
+        }
+        --]]
+
+        if not automatic_mod_tests.functions.isTableEmpty(entity.inputs) then
+            for _, tool_name in pairs(entity.inputs) do
+                all_lab_tools[tool_name] = true
+            end
+        end
+    end
+
+    -- also show why satellite is not craftable:
+    all_lab_tools["satellite"] = true
+
+
+    log("-----------------------------------------------------------------------------------------------")
+    log("function-tests.lua - log => We will print information about craftability of each science pack: ")
+    for tool_name, _ in pairs(all_lab_tools) do
+        if craftable_items[tool_name] ~= nil then
+            log("function-tests.lua - log => science pack '" .. tool_name .. "' is craftable - OK")
+        else
+            log("function-tests.lua - log => science pack '" .. tool_name .. "' is not craftable - WRONG - its ingredients: ");
+            local indent_level = 1
+            -- to prevent "infinite loop":
+            local already_checked_items = {}
+            automatic_mod_tests.functions.print_uncraftable_recipes_recurrent(tool_name, indent_level, already_checked_items, researched_recipes, craftable_items, craftable_fluids, difficulty)
+        end
+    end
+end
+
+
+function automatic_mod_tests.functions.print_uncraftable_recipes_recurrent(item_to_check, indent_level, already_checked_items, researched_recipes, craftable_items, craftable_fluids, difficulty)
+    local indent = automatic_mod_tests.functions.make_indent(indent_level)
+
+    if (craftable_items[item_to_check] ~= nil) or (craftable_fluids[item_to_check] ~= nil) then
+        log(indent .. "'" .. item_to_check .. "' - craftable (OK)")
+        return
+    end
+
+    if already_checked_items[item_to_check] ~= nil then
+        log(indent .. "    " .. item_to_check .. " not craftable (WRONG, already checked)")
+        return
+    end
+
+    already_checked_items[item_to_check] = true
+
+    log(indent .. "'" .. item_to_check .. "' not craftable (WRONG) - possible recipes:")
+
+    local anyRecipeFound = false
+
+    for researched_recipe_name, _ in pairs(researched_recipes) do
+        local recipe_results = automatic_mod_tests.functions.convert_recipe_results(data.raw.recipe[researched_recipe_name], difficulty)
+
+        if automatic_mod_tests.functions.tableFindValue(recipe_results.craftable_items, item_to_check) or automatic_mod_tests.functions.tableFindValue(recipe_results.craftable_fluids, item_to_check) then
+            anyRecipeFound = true
+
+            local ingredients = automatic_mod_tests.functions.convert_recipe_ingredients(data.raw.recipe[researched_recipe_name], difficulty)
+
+            log(indent .. " - recipe '" .. researched_recipe_name .. "' ingredients:")
+            for _, ingredient_name in pairs(ingredients.craftable_items) do
+                automatic_mod_tests.functions.print_uncraftable_recipes_recurrent(ingredient_name, indent_level + 1, already_checked_items, researched_recipes, craftable_items, craftable_fluids, difficulty)
+            end
+            for _, ingredient_name in pairs(ingredients.craftable_fluids) do
+                automatic_mod_tests.functions.print_uncraftable_recipes_recurrent(ingredient_name, indent_level + 1, already_checked_items, researched_recipes, craftable_items, craftable_fluids, difficulty)
+            end
+        end
+    end
+
+    if not anyRecipeFound then
+        log (indent .. " - unable to find any researched recipe for '" .. item_to_check .. "'!")
+    end
+end
+
+function automatic_mod_tests.functions.make_indent(indent_level)
+    local indent = ""
+    for _ = 1,indent_level do indent = indent .. "    " end
+    return indent
+end
+
+
+
+
+
+-- -----------------------------------------------------------------------------
+-- helper functions
+
+
+function automatic_mod_tests.functions.is_item_craftable(craftable_items, item_name)
+    if craftable_items[item_name] ~= nil then
+        return true
+    end
+    return false
+end
+
+-- Note: use it only once initially. Later check craftablte_items instead
+function automatic_mod_tests.functions.is_entity_craftable(researched_recipes, craftable_items, item_name, is_beginning_of_game)
+    if is_beginning_of_game then
+        if researched_recipes[item_name] ~= nil then
+            return true
+        end
+    else
+        -- TODO: improve this check: find item which corresponds to the entity (because maybe they have different names?)
+        if craftable_items[item_name] ~= nil then
+            return true
+        end
+    end
+    return false
+end
+
+
+function automatic_mod_tests.functions.convert_recipe_results(recipeObject, difficulty)
+    local results = { craftable_items = {}, craftable_fluids = {}}
+    local recipeObjectByDifficulty = {}
+
+    if recipeObject[difficulty] ~= nil then
+        recipeObjectByDifficulty = recipeObject[difficulty]
+    else
+        recipeObjectByDifficulty = recipeObject
+    end
+
+    if recipeObjectByDifficulty.results then
+        for _,result in pairs(recipeObjectByDifficulty.results) do
+            if result.name ~= nil then
+                if result.type == nil or result.type == 'item' then
+                    table.insert(results.craftable_items, result.name)
+                elseif result.type == 'fluid' then
+                    table.insert(results.craftable_fluids, result.name)
+                end
+            else
+                table.insert(results.craftable_items, result[1])
+            end
+        end
+        return results
+    end
+
+    if recipeObjectByDifficulty.result then
+        table.insert(results.craftable_items, recipeObjectByDifficulty.result)
+        return results
+    end
+
+    return results;
+end
+
+function automatic_mod_tests.functions.convert_recipe_ingredients(recipeObject, difficulty)
+    local results = { craftable_items = {}, craftable_fluids = {}}
+    local recipeObjectByDifficulty = {};
+
+    if recipeObject[difficulty] ~= nil then
+        recipeObjectByDifficulty = recipeObject[difficulty]
+    else
+        recipeObjectByDifficulty = recipeObject
+    end
+
+    if recipeObjectByDifficulty.ingredients then
+        for _,result in pairs(recipeObjectByDifficulty.ingredients) do
+            if result.name ~= nil then
+                if result.type == nil or result.type == 'item' then
+                    table.insert(results.craftable_items, result.name)
+                elseif result.type == 'fluid' then
+                    table.insert(results.craftable_fluids, result.name)
+                end
+            else
+                table.insert(results.craftable_items, result[1])
+            end
+        end
+        return results
+    end
+
+    return results
+end
+
+
+function automatic_mod_tests.functions.convert_technology_ingredients(ingredients)
+    local results = {}
+
+    for _,result in pairs(ingredients) do
+        if result.name ~= nil then
+            if result.type == nil or result.type == 'item' or result.type == 'tool' then
+                table.insert(results, result.name)
+            end
+        else
+            table.insert(results, result[1])
+        end
+    end
+    return results
+end
+
+
+function automatic_mod_tests.functions.ternary(cond, T, F)
+    -- function by user daurnimator from https://stackoverflow.com/questions/5525817/inline-conditions-in-lua-a-b-yes-no/5529577#5529577
+    if cond then return T else return F end
+end
+
+function automatic_mod_tests.functions.tableFindValue(aTable, value)
+    for _, v in pairs(aTable) do
+        if (v == value) then
+            return true
+        end
+    end
+    return false
+end
+
+function automatic_mod_tests.functions.tableLength(myTable)
+    -- function by user u0b34a0f6ae from https://stackoverflow.com/questions/2705793/how-to-get-number-of-entries-in-a-lua-table/2705804#2705804
+    local count = 0
+    for _ in pairs(myTable) do count = count + 1 end
+    return count
+end
+
+function automatic_mod_tests.functions.isTableEmpty(myTable)
+    -- function by user Norman Ramsey: https://stackoverflow.com/questions/1252539/most-efficient-way-to-determine-if-a-lua-table-is-empty-contains-no-entries/1252776#1252776
+    if next(myTable) == nil then
+        return true
+    end
+    return false
+end

--- a/function.lua
+++ b/function.lua
@@ -9,6 +9,21 @@ function momoTweak.replace_with_ingredient(recipeName, old, newItem)
   bobmods.lib.recipe.add_ingredient(recipeName, newItem)
 end
 
+function momoTweak.replace_with_ingredient_in_all_recipes(old, newItem)
+	for i,recipe in pairs(data.raw.recipe) do
+		if recipe.ingredients then
+			for j, ing in pairs(recipe.ingredients) do
+				local item = {}
+				if ing then item = bobmods.lib.item.ingredient_simple(ing) else item.name = "__" end
+				if  item.name == old then
+					log("MTKL Recipe: replacing ".. old .. " => " .. newItem .. " in recipe: " .. recipe.name)
+					momoTweak.replace_with_ingredient(recipe.name, old, newItem)
+				end
+			end
+		end
+	end
+end
+
 function momoTweak.multiple_amount_ingredient(recipeName, itemName, multiply)
   local oldValue = 0
   -- check for straing 
@@ -178,7 +193,7 @@ function momoTweak.createRecipe(cat ,results, ingredients, energy, tech, extrana
   local namegen = momoTweak.genRecipeNameFromResult(result)
   local enabled = "false"
   if tech == true then
-    enabled = "true"
+    enabled = true
   end 
   
   if data.raw.recipe[namegen] then namegen = "momo-" .. extraname .. result.name .. "-N" .. result.amount end

--- a/function/helper.lua
+++ b/function/helper.lua
@@ -27,7 +27,7 @@ function momoIRTweak.DeepCopy(tableToCopy)
 end
 
 function momoIRTweak.tableAddValueIfUnique(aTable, value)
-	for k, v in pairs(aTable) do
+	for _, v in pairs(aTable) do
 	    if (v == value) then
 	        return
 	    end
@@ -36,7 +36,7 @@ function momoIRTweak.tableAddValueIfUnique(aTable, value)
 end
 
 function momoIRTweak.tableFindValue(aTable, value)
-	for k, v in pairs(aTable) do
+	for _, v in pairs(aTable) do
 		if (v == value) then
 			return true
 		end
@@ -58,7 +58,7 @@ function momoIRTweak.DumpTable(_table)
 		for k, v in pairs(_table) do 
 			momoIRTweak.indentAmount = momoIRTweak.indentAmount + 1
 			local indent = ""
-			for i=1, momoIRTweak.indentAmount do 
+			for _ = 1, momoIRTweak.indentAmount do
 				indent = indent .. "   "
 			end
 			momoIRTweak.AddStringToDumpStack("\n" .. indent .. tostring(k) .. ":")

--- a/function/recipe.lua
+++ b/function/recipe.lua
@@ -66,6 +66,20 @@ function momoIRTweak.recipe.ChangePrototypeResults(prototype, newName, results)
 	end
 end
 
+function momoIRTweak.recipe.ChangeRecipeResults(recipeName, results)
+	local recipe = data.raw.recipe[recipeName]
+	if not recipe then
+		return
+	end
+
+	if (recipe.normal) then
+		momoIRTweak.recipe.ChangePrototypeResults(recipe.normal, recipeName, table.deepcopy(results))
+		momoIRTweak.recipe.ChangePrototypeResults(recipe.expensive, recipeName, results)
+	else
+		momoIRTweak.recipe.ChangePrototypeResults(recipe, recipeName, results)
+	end
+end
+
 -----------------------------------------------------------------------------------------
 
 --- Ingredient.
@@ -255,7 +269,7 @@ function momoIRTweak.recipe.SetResultCount(recipeName, amount)
 		else
 			if (recipe.results) then
 				if not (recipe.results[2]) then
-					recipe.results[1].amonut = amount
+					recipe.results[1].amount = amount
 				else
 					momoIRTweak.Log("recipe [" .. recipeName .. "] have multiple results.")
 				end
@@ -359,6 +373,44 @@ function momoIRTweak.recipe.SetLocalizedName(recipeName, localName)
 	end
 end
 
+
+function momoIRTweak.recipe.reEnableRecipe(recipeName, isEnabled)
+	local recipe = data.raw.recipe[recipeName]
+	if (recipe) then
+		if (recipe.normal) then
+			recipe.normal.hidden = false
+			recipe.normal.enabled = isEnabled
+			recipe.expensive.hidden = false
+			recipe.expensive.enabled = isEnabled
+		else
+			recipe.hidden = false
+			recipe.enabled = isEnabled
+		end
+	end
+end
+
+function momoIRTweak.recipe.reEnableItem(itemName)
+	local item = data.raw.item[itemName];
+	if item then
+		if not item.flags then
+			item.flags = {}
+		end
+
+		local i=1
+		while i <= #item.flags do
+			if item.flags[i] == "hidden" then
+				-- Note: item.flags is array - not "Set" ( see https://forum.multitheftauto.com/topic/130181-lua-tables-as-sets-instead-of-arrays/ )
+				-- In this case we dont increase index "i" because after removal of item of table(array) the indexes "shift". See: https://stackoverflow.com/questions/12394841/safely-remove-items-from-an-array-table-while-iterating/12397571#12397571  and https://stackoverflow.com/questions/1758991/how-to-remove-a-lua-table-entry-by-its-key
+				-- We need to iterate over all items of array because its possible that more than 1 item has "hidden" value - so no early return here.
+				table.remove(item.flags, i)
+			else
+				i = i + 1
+			end
+		end
+
+	end
+end
+
 -- Warning this function may take half a year to finish
 function momoIRTweak.DumpRecipes()
 	momoIRTweak.dumpRecipesText = "Recipe dump \n"
@@ -368,4 +420,3 @@ function momoIRTweak.DumpRecipes()
 	end
 	momoIRTweak.Log(momoIRTweak.dumpText)
 end
-

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "MomosTweak",
-  "version": "1.1.11",
+  "version": "1.2.0",
   "factorio_version": "1.1",
   "title": "MomosTweak",
   "author": "Archemide",
@@ -26,6 +26,7 @@
 	  "angelssmelting >= 0.6.13",
 	  
 	  "? angelsbioprocessing >= 0.7.16",
+	  "? angelsindustries >= 0.4.16",
 	  "? MoreSciencePacks-for1_1 >= 0.1.24",
 	  "? ScienceCostTweakerM >= 0.17.6",
 	  "? underground-pipe-pack >= 0.17.0",
@@ -36,6 +37,7 @@
 	  "? bobvehicleequipment >= 1.0.1",
 	  "? LB-Modular-Chests >= 0.17.7",
 	  "? omnilib >= 3.0.4",
+	  "? P-U-M-P-S >= 1.1.66",
 	  "? SeaBlock >= 0.5.11",
 	  "? ShinyIcons >= 0.17.1",
 	  "? SpaceMod >= 1.0.0"

--- a/locale/en/settings.cfg
+++ b/locale/en/settings.cfg
@@ -2,7 +2,7 @@
 momo-enable-30-sci-preset=30 new Science Pack Result preset
 momo-fix-angels-chemistry-machine=Using angel's chemistry machine
 momo-30-sci-extreme=-- Include 30 More Science Packs mod (extreme)
-momo-30-sci-ingredient-amount=-- Amount science ingredients for Accumulators chip
+momo-30-sci-ingredient-amount=-- Additional amount of science ingredients in "Accumulators chip" recipes
 momo-harder-module=Enable harder recipe for module
 momo-harder-logistic=Enable harder recipe for belt and splitter
 momo-enable-progress-electronics=Enable electronics progress
@@ -24,7 +24,7 @@ momo-evo-reduce-factor=[Experiment] Decrease bitter evolution/minute
 [mod-setting-description]
 momo-enable-30-sci-preset=0 => Use MSP mod settings || 1 => Override normal preset || 2 => Override hard preset || 3 => Override very hard preset
 momo-fix-angels-chemistry-machine=Reuse angel's chemistry machine for sci component crafting
-momo-30-sci-extreme=Need More Science Packs - 30 new Science Packs by usafphoenix and Using angel's chemistry machine to work
+momo-30-sci-extreme=Needs "MSP - 30 new Science Packs" mod by usafphoenix and enabled setting "Using angel's chemistry machine" to work. MSP's 30 Packs will be treated also as Intermediate crafting ingredients for vanilla science packs (to be specific: for each of 6 "accumulator chips"). DO NOT TOGGLE THIS during running game with active labs or labs containing MSP packs.
 momo-30-sci-ingredient-amount=This is an addition value so if 2 | 1 + 2 equal 3 not 1 * 2 equal 2 better left it 0. This settings is for masochist!
 momo-enable-bob-extend=Enable bob's Extended content (Make game way more harder) Work in progress
 momo-enable-bob-extend-frame=<<Bob's Extended must Enable>> Enable Machine Structure components

--- a/locale/en/settings.cfg
+++ b/locale/en/settings.cfg
@@ -34,4 +34,4 @@ momo-enable-bob-extendenginetech=<<Bob's Extended must Enable>> Add some materia
 momo-enable-bob-extend-ele=<<Bob's Extended must Enable>> Add intermediate materials for electronics
 momo-enable-bob-extend-slag=<<Bob's Extended must Enable>>
 momo-enable-bob-extend-tech=<<Bob's Extended must Enable>> Currently have nothing yet!
-momo-evo-reduce-factor= Set to 0 = diable || value should be between 0.3 - 1.3, over 1.3 evolution factor may not increase 
+momo-evo-reduce-factor= Set to 0 = disable || value should be between 0.3 - 1.3, over 1.3 evolution factor may not increase 

--- a/prototypes/bobextended/bobextended-update-frame.lua
+++ b/prototypes/bobextended/bobextended-update-frame.lua
@@ -43,6 +43,7 @@ function momoTweak.require.ExtendedFrameUpdate()
 	end
 	bobmods.lib.tech.add_recipe_unlock(unlock_tech, "basic-structure-components")
 	bobmods.lib.tech.add_recipe_unlock(momoTweak.get_tech_of_recipe("engine-unit"), "intermediate-structure-components")
+	bobmods.lib.tech.add_recipe_unlock("angels-metallurgy-2", "intermediate-structure-components")
 	bobmods.lib.tech.add_recipe_unlock("automation-3", "advanced-structure-components")
 	bobmods.lib.tech.add_recipe_unlock("automation-5", "anotherworld-structure-components")
 

--- a/prototypes/fix-seablock-machines.lua
+++ b/prototypes/fix-seablock-machines.lua
@@ -10,4 +10,13 @@ if mods["SeaBlock"] then
 	bobmods.lib.tech.add_recipe_unlock("steel-processing", "momo-tinplate-pack-1-N1")
 	bobmods.lib.tech.remove_recipe_unlock("logistic-science-pack", "momo-plate-pack-1-N1")
 	bobmods.lib.tech.remove_recipe_unlock("logistic-science-pack", "momo-tinplate-pack-1-N1")
+
+	-- rubber is not craftable at "more-science-pack-7" level - thus blocking progression
+	bobmods.lib.recipe.remove_ingredient("constant-combinator", "rubber")
+	bobmods.lib.recipe.remove_ingredient("arithmetic-combinator", "rubber")
+	bobmods.lib.recipe.remove_ingredient("decider-combinator", "rubber")
+
+	if momoTweak.mods.msp then
+		bobmods.lib.tech.add_recipe_unlock("angels-coal-processing", "more-science-pack-5")
+	end
 end

--- a/prototypes/recipe/sandclay.lua
+++ b/prototypes/recipe/sandclay.lua
@@ -99,18 +99,21 @@ if data.raw["recipe-category"]["biofarm-mod-crushing"] then
 	4, momoTweak.get_tech_of_recipe("bi_recipe_stone_crusher"), "sand-upgrade")
 end
 
+
+local stoneCrushedIngredientsMultiplier = 2
 if mods["SeaBlock"] then
-    momoTweak.createRecipe(limestoneSandCategory,
-    {{"solid-sand", 3}},
-    {{"stone-crushed", 2}},
-    4, true, "stone-crushed-crushing-to-sand")
-
-
-    momoTweak.createRecipe(limestoneSandCategory,
-    {{"stone-crushed", 2}},
-    {{"stone", 3}},
-    4, true, "stone-crushing-to-crushed-stone")
+    stoneCrushedIngredientsMultiplier = 1
 end
+momoTweak.createRecipe(limestoneSandCategory,
+{{"solid-sand", 3}},
+{{"stone-crushed", 2 * stoneCrushedIngredientsMultiplier}},
+4, true, "stone-crushed-crushing-to-sand")
+
+
+momoTweak.createRecipe(limestoneSandCategory,
+{{"stone-crushed", 2}},
+{{"stone", 3 * stoneCrushedIngredientsMultiplier}},
+4, true, "stone-crushing-to-crushed-stone")
 
 
 

--- a/prototypes/sci/sci30recipe.lua
+++ b/prototypes/sci/sci30recipe.lua
@@ -41,8 +41,9 @@ function momoTweak.require.Sci30Recipe()
 		bobmods.lib.recipe.add_ingredient("more-science-pack-21", {"silver-plate", 8})
 		bobmods.lib.recipe.add_ingredient("more-science-pack-25", {"silver-plate", 4})
 		
-		bobmods.lib.recipe.replace_ingredient("more-science-pack-17", "medium-electric-pole", "medium-electric-pole-3")
-		bobmods.lib.recipe.replace_ingredient("more-science-pack-17", "big-electric-pole", "big-electric-pole-3")
+		bobmods.lib.recipe.replace_ingredient("more-science-pack-17", "medium-electric-pole", "medium-electric-pole-2")
+		bobmods.lib.recipe.replace_ingredient("more-science-pack-17", "big-electric-pole", "big-electric-pole-2")
+		bobmods.lib.recipe.replace_ingredient("more-science-pack-17", "substation", "substation-2")
 		bobmods.lib.recipe.add_ingredient("more-science-pack-17", {momoTweak.ele.unit[2], 3})
 		
 		bobmods.lib.recipe.add_ingredient("more-science-pack-18", {ele.board[3], 20})


### PR DESCRIPTION
Change:
- added compatibility with following mods: angelsindustries ( https://mods.factorio.com/mod/angelsindustries ), "P-U-M-P-S" / "osm-lib" ( https://mods.factorio.com/mod/P-U-M-P-S )

Added:
- tests for "progression block". See: function/recipe.lua . They can be executed manually at end of data-final-fixes.lua to see if anything like recipes, technologies etc block player progression up to "satellite". If player can craft satellite then OK - if not then in factorio-current.log (in your Factorio dir) you should see reasons why some science packs and their ingredients are not craftable.

Fixed:
- some things blocking craftability of science packs related to mods: angelsindustries, MoreSciencePacks-for1_1, SeaBlock
    - Thanks to user mlxix for report: https://mods.factorio.com/mod/MomosTweak/discussion/630abdf4df42b7581198be96